### PR TITLE
baremetal-riscv32nf: Fix typo in syntax override

### DIFF
--- a/conf/machine/baremetal-riscv32nf.conf
+++ b/conf/machine/baremetal-riscv32nf.conf
@@ -6,8 +6,8 @@ DEFAULTTUNE = "riscv32nf"
 require conf/machine/include/qemu.inc
 require conf/machine/include/riscv/tune-riscv.inc
 
-PREFERRED_VERSION:openocd-native = "riscv"
-PREFERRED_VERSION:openocd = "riscv"
+PREFERRED_VERSION_openocd-native = "riscv"
+PREFERRED_VERSION_openocd = "riscv"
 
 # qemuboot options
 QB_MACHINE = "-machine virt"


### PR DESCRIPTION
In my perspective it's a typo. But I would like to have it reviewed.
